### PR TITLE
🎨 style: Update CSS to reset margin-bottom for specific form classes …

### DIFF
--- a/client/src/forked-style-custom/custom-daniel-ai.css
+++ b/client/src/forked-style-custom/custom-daniel-ai.css
@@ -94,9 +94,9 @@ div[role='listbox'] div[role='option'] [class^='icon-'].shrink-0.overflow-hidden
   height: 24px !important;
 }
 
-/* Hide the margin-bottom on the chat container on desktop screens */
+/* Reset margin-bottom only for forms with specific class combinations on desktop screens */
 @media screen and (min-width: 640px) {
-  form.mx-auto.flex.flex-row.gap-3.sm\:px-2 {
+  form.mx-auto.flex.flex-row.gap-3.sm\:px-2.transition-all.duration-200.sm\:mb-28 {
     margin-bottom: 0 !important;
   }
 }


### PR DESCRIPTION
# 🎨 style: Update CSS to reset margin-bottom for specific form classes on desktop screens


## Summary

Update CSS to reset margin-bottom for specific form classes on desktop screens

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update