### PR TITLE
🔒 ci: Add fork upstream-sync integrity system

### DIFF
--- a/.fork/README.md
+++ b/.fork/README.md
@@ -1,0 +1,102 @@
+# Fork sync hardening
+
+This directory holds the machinery that keeps our fork in sync with upstream
+LibreChat **without silently losing fork changes**, and that makes conflict PRs
+safe enough for an agent to resolve from the PR URL alone.
+
+## Why this exists
+
+Our fork commits changes directly to `main`. ~97% of those changes are isolated
+in `forked-code/` and `forked-code-custom/` directories that upstream never
+touches. The remaining risk is a small number of **inline edits to upstream
+files** (thin wiring). When upstream rewrites one of those exact lines, two bad
+things used to happen:
+
+1. A clean text-merge could **silently drop** a fork edit. Once dropped on
+   `main`, our line equals upstream's line, so it never conflicts again — the
+   loss is permanent and invisible.
+2. The old sync job committed conflict markers as a normal merge commit (which
+   GitHub still reports as "mergeable") and force-pushed the conflict branch
+   hourly, clobbering any in-progress resolution.
+
+## How it works
+
+### Sentinels (the silent-loss defense)
+
+Every intentional inline edit to an upstream file is tagged in code with a
+unique marker comment and registered in [`sentinels.tsv`](./sentinels.tsv):
+
+```ts
+// FORK-SENTINEL:litellm-streamusage — opt LiteLLM agents into streamUsage so createRun keeps streamed usage
+applyLiteLLMStreamUsage(agents);
+```
+
+```
+litellm-streamusage  api/server/controllers/agents/client.js  <description>  applyLiteLLMStreamUsage(
+```
+
+The marker is only a comment, so each registry row also carries a **code anchor**
+(the last column) — a fixed substring of the fork *behavior*, here
+`applyLiteLLMStreamUsage(`. [`verify-sentinels.sh`](./verify-sentinels.sh) asserts
+that for every row both the `FORK-SENTINEL:<id>` marker **and** its anchor still
+exist in the file, and that no tracked file carries an unregistered marker. The
+anchor matters because a merge could delete the behavior line and leave the
+comment behind; without it that loss would pass. If a merge (or any PR) drops a
+fork edit, the marker or its anchor disappears and verification **fails loudly**
+instead of the change vanishing silently.
+
+### The sync job (`.github/workflows/sync-upstream.yml`)
+
+Runs hourly:
+
+- **Open conflict PR exists?** → pause. Never touch a branch someone is
+  resolving.
+- **No upstream changes?** → exit.
+- **Clean text-merge + sentinels intact?** → push straight to `main`. No human.
+- **Clean text-merge but a sentinel vanished?** → escalate to a conflict PR
+  (reason `dropped-sentinel`).
+- **Real conflict?** → commit the merge with `zdiff3` markers as a proper
+  2-parent merge commit and open a conflict PR (reason `conflict-markers`).
+
+### The guard (`.github/workflows/sync-pr-guard.yml`)
+
+Runs on every PR into `main` and blocks merge unless:
+
+- no conflict markers remain in source, and
+- all fork sentinels are intact.
+
+Mark **Fork integrity** a required status check in branch protection for `main`
+so a markered or fork-change-dropping PR cannot be merged.
+
+## Adding a fork edit to an upstream file
+
+1. Make the edit as small as possible (prefer wiring into `forked-code*/`).
+2. Tag it with a `// FORK-SENTINEL:<id>` comment on or next to the changed line.
+3. Add a row to [`sentinels.tsv`](./sentinels.tsv): `id <TAB> file <TAB> description <TAB> anchor`.
+   The anchor is a fixed substring of the behavior (a call or JSX tag, e.g.
+   `<RouteGuard`) that is unique within the file — not the comment text.
+4. Run `bash .fork/verify-sentinels.sh` locally — it must pass.
+
+## Resolving a conflict PR
+
+Spin up an agent and give it the PR URL. Everything it needs is in the PR body:
+the reason, the conflicting files (or the dropped sentinel), and the steps.
+Resolve every conflict / re-apply the dropped edit, preserving **both**
+upstream's and the fork's intent, never deleting a `FORK-SENTINEL:<id>`, commit,
+and push. The guard + existing CI must be green before merge.
+
+**Merge the conflict PR with a merge commit — never squash or rebase.** The
+branch carries a real 2-parent merge commit; that is the only thing that records
+upstream as merged into `main`. Squash/rebase discards the upstream parent, so the
+next sync reprocesses the same upstream range and re-conflicts. If the repo allows
+squash/rebase merges, either disable them for `main` in branch-protection settings
+or be careful to pick "Create a merge commit" for these PRs.
+
+## Future option: rebased patch series (Model B)
+
+The "gold standard" for forks is keeping fork changes as a clean patch series
+rebased on top of upstream, where conflicts surface per-patch and loss is
+impossible by design. We do **not** use it today: our changes are interleaved
+into `main`'s history with sync merges, so there is no separable stack to
+rebase, and rebasing a deployed `main` rewrites shared history. If inline edits
+ever proliferate, restructure fork changes into a rebased stack and revisit.

--- a/.fork/sentinels.tsv
+++ b/.fork/sentinels.tsv
@@ -1,0 +1,44 @@
+# Fork sentinel registry — see .fork/README.md
+#
+# Every intentional inline edit to an UPSTREAM file is tagged in code with a
+# unique `// FORK-SENTINEL:<id>` comment and registered here. CI (.github/
+# workflows/sync-pr-guard.yml) and the sync job (.github/workflows/
+# sync-upstream.yml) fail if any registered sentinel disappears from its file —
+# converting the previously-silent loss of a fork change into a loud failure.
+#
+# Format (TAB-separated, no leading spaces):
+#   id <TAB> file <TAB> description <TAB> anchor
+#
+# Rules:
+#   - id: lowercase kebab-case starting with a letter, unique, stable.
+#         Matches the code marker FORK-SENTINEL:<id>.
+#   - file: repo-relative path of the upstream file carrying the edit.
+#   - description: the fork intent — what would break if this edit vanished.
+#   - anchor: a fixed substring of the fork BEHAVIOR that must still exist in
+#         the file (verified with grep -F). The marker is a comment; without an
+#         anchor a merge could delete the behavior, keep the comment, and pass.
+#         Pick the most stable distinctive token of the edit (a call or JSX tag)
+#         and keep it unique within the file. Required. The verifier rejects an
+#         anchor that matches more than one line, so avoid tokens that are a
+#         substring of a sibling line (e.g. `name:` lives inside `short_name:` —
+#         anchor the distinct line instead).
+#
+# Example row (id <TAB> file <TAB> description <TAB> anchor):
+#   my-feature	client/src/components/Chat/Example.tsx	What breaks if this edit vanishes	<ExampleWidget
+litellm-streamusage	api/server/controllers/agents/client.js	Opt LiteLLM agents into streamUsage so upstream createRun keeps streamed token usage	applyLiteLLMStreamUsage(
+sync-response-usage	api/server/controllers/agents/request.js	Set token/cost usage on the response before the final SSE event	await syncResponseUsage(
+sync-response-usage-persist	api/server/controllers/agents/request.js	Background-persist cost metadata without blocking the SSE final event	persist: true
+init-forked-code	api/server/index.js	Mount forked-code routes/extensions onto the Express app	initForkedCode(
+landing-suggestions-margin	client/src/components/Chat/Landing.tsx	Extra bottom margin so PromptSuggestions clears the input	mb-28
+prompt-suggestions	client/src/components/Chat/Landing.tsx	Fork-only starter prompt suggestions on the landing screen	<PromptSuggestions
+modelspec-badges	client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx	Fork-only model badges under the spec description	<ModelBadges
+modelspec-capabilities	client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx	Fork-only capability icons aligned to the spec row top	<CapabilityIcons
+searchresults-badges	client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx	Fork-only model badges in endpoint search results	<ModelBadges
+searchresults-capabilities	client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx	Fork-only capability icons in endpoint search results	<CapabilityIcons
+response-cost	client/src/components/Chat/Messages/HoverButtons.tsx	Fork-only per-message cost display	<ResponseCost
+customer-portal-menu	client/src/components/Nav/AccountSettings.tsx	Fork-only billing portal entry in the account menu	<CustomerPortalMenuItem
+forked-customizations	client/src/main.jsx	Mounts fork-only global customizations and custom CSS import	<ForkedCustomizations
+route-guard	client/src/routes/index.tsx	Fork-only auth/subscription route gating around app routes	<RouteGuard
+brand-manifest	client/vite.config.ts	PWA manifest fork branding (name + short_name)	short_name: 'Daniel AI'
+brand-title	client/index.html	Page title and meta description (fork branding)	<title>Daniel AI</title>
+claude-fork-pointer	CLAUDE.md	Fork guidance entrypoint: @FORK.md import + FORK-SENTINEL rule for agents	Read **`FORK.md`**

--- a/.fork/verify-sentinels.sh
+++ b/.fork/verify-sentinels.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Verify every fork sentinel registered in .fork/sentinels.tsv:
+#   - its FORK-SENTINEL:<id> marker still exists in the registered file,
+#   - the registered code anchor (the fork behavior) still exists in that file,
+#   - no tracked file carries a marker without a matching (id, file) row.
+#
+# The anchor check stops a merge from deleting the fork behavior while leaving the
+# marker comment behind — that would otherwise pass, since the marker is only a
+# comment. Each row must carry an anchor (4th column), and that anchor must match
+# EXACTLY ONE line in the file: an anchor that is a substring of a sibling line
+# (e.g. `name:` inside `short_name:`) could let one line be dropped while the
+# other masks the loss, so an ambiguous (multi-line) anchor is rejected too.
+#
+# Exit 0  -> all registered sentinels present with a unique anchor, no orphans.
+# Exit 1  -> a marker or its anchor is missing (a fork change was dropped), an
+#            anchor matches multiple lines (ambiguous), a row lacks an anchor, or
+#            an orphan marker exists (edit never registered).
+#
+# Usage: bash .fork/verify-sentinels.sh [registry-path]
+#
+# SKIP_ORPHAN_SCAN (env): when set, run pass 1 only (registered rows intact) and
+# skip pass 2 (the orphan scan). Use when verifying a DIFFERENT registry against
+# this working tree — e.g. the PR guard runs the BASE registry over the PR tree to
+# prove no base-registered edit was dropped; the PR's NEW markers are legitimate
+# there and must not be flagged as orphans.
+set -euo pipefail
+
+REGISTRY="${1:-.fork/sentinels.tsv}"
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "verify-sentinels: registry not found: $REGISTRY" >&2
+  exit 1
+fi
+
+registered_ids=()
+registered_pairs=""
+missing_report=""
+status=0
+
+# --- Pass 1: every registered marker AND its code anchor must exist in its file ---
+while IFS=$'\t' read -r id file description anchor || [[ -n "${id:-}" ]]; do
+  [[ -z "${id:-}" || "$id" == \#* ]] && continue
+  registered_ids+=("$id")
+  registered_pairs+="${id}"$'\t'"${file}"$'\n'
+  if [[ -z "${anchor:-}" ]]; then
+    missing_report+="  NO ANCHOR     FORK-SENTINEL:${id} registry row is missing the required code-anchor (4th) column"$'\n'
+    status=1
+    continue
+  fi
+  if [[ ! -f "$file" ]]; then
+    missing_report+="  MISSING FILE  FORK-SENTINEL:${id} → ${file} (${description})"$'\n'
+    status=1
+    continue
+  fi
+  if ! grep -qF "FORK-SENTINEL:${id}" "$file"; then
+    missing_report+="  DROPPED       FORK-SENTINEL:${id} expected in ${file} — ${description}"$'\n'
+    status=1
+    continue
+  fi
+  anchor_hits=$(grep -cF "$anchor" "$file" || true)
+  if [[ "$anchor_hits" -eq 0 ]]; then
+    missing_report+="  BEHAVIOR LOST FORK-SENTINEL:${id} marker present in ${file} but its code anchor [${anchor}] is gone — ${description}"$'\n'
+    status=1
+  elif [[ "$anchor_hits" -ne 1 ]]; then
+    missing_report+="  AMBIGUOUS     FORK-SENTINEL:${id} anchor [${anchor}] matches ${anchor_hits} lines in ${file}; pick a token unique within the file so a partial drop can't hide behind a sibling line — ${description}"$'\n'
+    status=1
+  fi
+done < "$REGISTRY"
+
+# --- Pass 2: every marker in the tree must be registered for the file it sits in ---
+# Sentinels tag inline edits to upstream files of ANY type — not just JS/TS. The
+# registry already covers .md (CLAUDE.md), .html (client/index.html), and config
+# (vite.config.ts). Scan EVERY tracked text file so a marker in markdown, HTML,
+# YAML, CSS, or config can't slip in unregistered. `git ls-files` keeps .gitignore
+# respected (no dist/node_modules); `grep -I` skips binaries. `.fork/` and the
+# top-level FORK.md are excluded because they are fork-owned docs that cite real
+# sentinel ids in prose (never upstream files carrying a code marker).
+#
+# The check is on the (id, file) PAIR, not the id alone. Reusing a registered id
+# in a second file would otherwise pass — yet that second edit has no row of its
+# own, so its later loss would go undetected (pass 1 still finds the id in the
+# original file). Binding to the pair forces every marker to a dedicated row.
+orphan_report=""
+is_registered_pair() {
+  printf '%s' "$registered_pairs" | grep -Fxq "${1}"$'\t'"${2}"
+}
+
+if [[ -z "${SKIP_ORPHAN_SCAN:-}" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  tracked_files=$(git ls-files -- . ':(exclude).fork/*' ':(exclude)FORK.md' || true)
+  if [[ -n "$tracked_files" ]]; then
+    while IFS= read -r hit; do
+      [[ -z "$hit" ]] && continue
+      file="${hit%%:FORK-SENTINEL:*}"
+      id="${hit##*:FORK-SENTINEL:}"
+      if ! is_registered_pair "$id" "$file"; then
+        orphan_report+="  ORPHAN        FORK-SENTINEL:${id} in ${file} has no matching row (id+file) in ${REGISTRY}"$'\n'
+        status=1
+      fi
+    done < <(printf '%s\n' "$tracked_files" | tr '\n' '\0' \
+      | xargs -0 grep -oIE 'FORK-SENTINEL:[a-z][a-z0-9-]*' 2>/dev/null | sort -u)
+  fi
+fi
+
+if [[ "$status" -ne 0 ]]; then
+  echo "Fork sentinel verification FAILED:"
+  [[ -n "$missing_report" ]] && printf '%s' "$missing_report"
+  [[ -n "$orphan_report" ]] && printf '%s' "$orphan_report"
+  exit 1
+fi
+
+if [[ -n "${SKIP_ORPHAN_SCAN:-}" ]]; then
+  echo "Fork sentinel verification passed (${#registered_ids[@]} registered, markers + anchors present; orphan scan skipped)."
+else
+  echo "Fork sentinel verification passed (${#registered_ids[@]} registered, markers + anchors present, no orphans)."
+fi

--- a/.github/workflows/sync-pr-guard.yml
+++ b/.github/workflows/sync-pr-guard.yml
@@ -1,0 +1,105 @@
+name: Fork Integrity Guard
+
+# Runs on every PR into main. Two fast, fork-specific gates that the rest of CI
+# does not cover:
+#   1. no committed conflict markers reach main
+#   2. no registered fork edit (FORK:<id> sentinel) is dropped by a change
+# Build / typecheck / lint are covered by the existing PR workflows.
+# Mark this job a required status check in branch protection for `main`.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  guard:
+    name: Fork integrity
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: No conflict markers in tracked files
+        run: |
+          set -euo pipefail
+          # Scan ALL tracked files (`git grep -I` skips binaries). The sync job can
+          # commit a conflict in ANY tracked file — root configs, workflows, docs,
+          # package files — so the scan must not be scoped to source dirs.
+          # `<<<<<<<` and `>>>>>>>` at line start unambiguously bracket a conflict;
+          # if neither is present there is no conflict.
+          if git grep -I -nE '^(<{7}|>{7})' -- .; then
+            echo "::error::Unresolved conflict markers found — resolve before merge."
+            exit 1
+          fi
+          echo "No conflict markers."
+
+      - name: No unresolved marker-less conflicts
+        run: |
+          # Binary / modify-delete conflicts have no `<<<<<<<` text for the scan
+          # above to catch. The sync job records them here; block until resolved.
+          # Test EXISTENCE (-e), not size (-s): resolution is DELETING the file, so a
+          # truncated/empty artifact must still block — `-s` would let it through.
+          if [ -e .fork/UNRESOLVED-CONFLICTS.txt ]; then
+            echo "::error::Unresolved marker-less conflicts remain — reconcile them and delete .fork/UNRESOLVED-CONFLICTS.txt"
+            cat .fork/UNRESOLVED-CONFLICTS.txt
+            exit 1
+          fi
+          echo "No marker-less conflict artifact."
+
+      - name: Fork sentinels intact
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Run the verifier LOGIC from the base branch, not from the PR. If we ran
+          # the PR's copy, a PR could edit verify-sentinels.sh to `exit 0` while
+          # dropping a sentinel and still satisfy this required check. Only the
+          # script is pinned to base; it scans the PR's working tree. Improvements
+          # to the verifier take effect on the next PR after they land on base.
+          verifier="$RUNNER_TEMP/verify-sentinels-base.sh"
+          if git cat-file -e "$BASE_SHA:.fork/verify-sentinels.sh" 2>/dev/null; then
+            git show "$BASE_SHA:.fork/verify-sentinels.sh" > "$verifier"
+          else
+            echo "::warning::base has no .fork/verify-sentinels.sh yet; using the PR copy (bootstrap PR introducing the guard)."
+            cp .fork/verify-sentinels.sh "$verifier"
+          fi
+
+          # (A) BASE rows must stay intact in the PR's working tree. Verifying the
+          # PR's own registry (step B) is not enough: a PR can drop a fork edit AND
+          # repurpose its registry row — same id, new file/anchor — so pass 1 of a
+          # PR-registry run finds the (now different) behavior and passes. Running
+          # the verifier with the BASE registry over the PR tree forces every
+          # base-registered (id, file, anchor) to still resolve to a present, unique
+          # marker. SKIP_ORPHAN_SCAN keeps the PR's NEW markers from tripping pass 2.
+          # Base rows are locked within a PR — relocating/removing a fork edit is
+          # done on main directly. Skipped on the bootstrap PR (base has no registry).
+          if git cat-file -e "$BASE_SHA:.fork/sentinels.tsv" 2>/dev/null; then
+            base_registry="$RUNNER_TEMP/sentinels-base.tsv"
+            git show "$BASE_SHA:.fork/sentinels.tsv" > "$base_registry"
+            if grep -q 'SKIP_ORPHAN_SCAN' "$verifier"; then
+              SKIP_ORPHAN_SCAN=1 bash "$verifier" "$base_registry"
+            else
+              # Pinned base verifier predates rows-only mode. For this one PR, fall
+              # back to the id-only no-shrink check (cannot catch same-id repurposing);
+              # once this change lands on base the branch above takes over next PR.
+              echo "::warning::base verifier lacks SKIP_ORPHAN_SCAN; using id-only no-shrink fallback this PR."
+              ids() { grep -vE '^[[:space:]]*(#|$)' "$1" | cut -f1 | sort -u; }
+              dropped=$(comm -23 <(ids "$base_registry") <(ids .fork/sentinels.tsv) || true)
+              if [[ -n "$dropped" ]]; then
+                echo "::error::PR drops fork-edit registry rows present on base — remove fork edits on main, not via a PR:"
+                printf '  %s\n' $dropped
+                exit 1
+              fi
+            fi
+            echo "No base-registered fork edits dropped relative to base."
+          fi
+
+          # (B) Validate the PR's OWN registry end-to-end against the PR tree: every
+          # row resolves to a present, unique marker + anchor, and no unregistered
+          # (orphan) marker exists anywhere in the tree (this covers new additions).
+          bash "$verifier"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -2,100 +2,165 @@ name: Sync Upstream
 
 on:
   schedule:
-    - cron: '0 */1 * * *' # Run every hour
+    - cron: '0 */1 * * *' # hourly
   workflow_dispatch:
 
 concurrency:
   group: sync-upstream
   cancel-in-progress: false
 
+env:
+  UPSTREAM_REPO: https://github.com/danny-avila/LibreChat.git
+  CONFLICT_BRANCH: upstream-sync-conflicts
+  CONFLICT_LABEL: upstream-sync-conflict
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           fetch-depth: 0
 
-      - name: Configure Git
+      - name: Configure git
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+          # zdiff3 puts the common ancestor inside conflict markers, so a
+          # human/agent resolving the PR sees fork / base / upstream.
+          git config merge.conflictStyle zdiff3
 
-      - name: Add Upstream Remote and Fetch
+      - name: Sync upstream
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
-          git remote add upstream https://github.com/danny-avila/LibreChat.git || true
-          git fetch upstream
+          set -euo pipefail
 
-      - name: Try merge
-        id: merge
-        run: |
-          if git merge --no-commit --no-ff upstream/main 2>&1; then
-            if [ ! -f .git/MERGE_HEAD ]; then
-              echo "No new changes to merge"
-              echo "result=no_changes" >> $GITHUB_OUTPUT
-            else
-              git commit -m "Sync upstream changes"
-              git push origin HEAD:main
-              echo "Changes were merged successfully"
-              echo "result=merged" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "Merge has conflicts"
-            echo "result=conflicts" >> $GITHUB_OUTPUT
-            git merge --abort
+          # --- Serialize guard: never touch an open conflict PR. ---
+          # While one is open, the branch is owned by whoever is resolving it;
+          # regenerating/force-pushing would clobber their work. Sync resumes
+          # automatically once the PR is merged or closed.
+          # Detect by HEAD BRANCH (always set), not label — labeling could fail
+          # to apply, which must never silently re-enable the clobbering force-push.
+          OPEN_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --head "$CONFLICT_BRANCH" --json number --jq '.[0].number // empty')
+          if [ -n "$OPEN_PR" ]; then
+            echo "Open conflict PR #$OPEN_PR exists — pausing sync until resolved."
+            echo "result=paused" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Trigger Build Workflow
-        if: steps.merge.outputs.result == 'merged'
+          git remote add upstream "$UPSTREAM_REPO" 2>/dev/null || true
+          git fetch upstream
+
+          # --- Attempt the merge without committing. ---
+          set +e
+          git merge --no-commit --no-ff upstream/main
+          MERGE_RC=$?
+          set -e
+
+          if [ ! -f .git/MERGE_HEAD ] && [ "$MERGE_RC" -eq 0 ]; then
+            echo "No new upstream changes."
+            echo "result=no_changes" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$MERGE_RC" -eq 0 ]; then
+            # Clean text-merge. Guard against a silently-dropped fork edit
+            # before letting it reach main unreviewed.
+            if bash .fork/verify-sentinels.sh > /tmp/sentinel-report.txt 2>&1; then
+              git commit -m "Sync upstream changes"
+              git push origin HEAD:main
+              echo "Clean merge pushed to main."
+              echo "result=merged" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            REASON="dropped-sentinel"
+          else
+            REASON="conflict-markers"
+          fi
+
+          echo "Escalating to a conflict PR (reason: $REASON)."
+          CONFLICTED_FILES="$(git diff --name-only --diff-filter=U || true)"
+          UPSTREAM_SHA="$(git rev-parse --short upstream/main)"
+
+          # Capture unmerged paths that carry NO text conflict markers (binary,
+          # modify/delete, rename, etc.). `git add -A` stages one side of these and
+          # hides them from the guard's marker scan, which would let an unresolved
+          # upstream conflict merge silently. Record them so the guard can block.
+          MARKERLESS=""
+          while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            if ! grep -qE '^(<{7}|>{7})' "$p" 2>/dev/null; then
+              st="$(git status --porcelain -- "$p" | head -1)"
+              [ -n "$st" ] && MARKERLESS="${MARKERLESS}${st}"$'\n'
+            fi
+          done < <(git ls-files -u | cut -f2 | sort -u)
+
+          # Commit the in-progress merge (markers and all) as a real 2-parent
+          # merge commit, so resolving + merging this PR records upstream as
+          # merged and the next run does not re-conflict the same commits.
+          git add -A
+          if [ -n "$MARKERLESS" ]; then
+            {
+              echo "# Upstream-sync conflicts with NO text markers (binary / modify-delete / rename, etc.)."
+              echo "# git could not write conflict markers, so 'git add -A' auto-staged one side of each."
+              echo "# Reconcile each path (upstream vs fork intent), then DELETE this file."
+              echo "# CI (sync-pr-guard) blocks merge while this file exists. Lines are 'git status' codes:"
+              printf '%s' "$MARKERLESS"
+            } > .fork/UNRESOLVED-CONFLICTS.txt
+            git add .fork/UNRESOLVED-CONFLICTS.txt
+          fi
+          git commit -m "Upstream sync — needs resolution ($REASON)"
+          git branch -f "$CONFLICT_BRANCH" HEAD
+          # Force is safe here: the guard above proved no open PR owns this branch.
+          git push -f origin "$CONFLICT_BRANCH"
+
+          {
+            echo "Automated upstream sync reached a state that needs human/agent resolution."
+            echo
+            echo "**Reason:** \`$REASON\`"
+            echo "**Upstream merged up to:** \`$UPSTREAM_SHA\`"
+            echo
+            if [ "$REASON" = "conflict-markers" ]; then
+              echo "**Files with conflict markers:**"
+              echo "$CONFLICTED_FILES" | sed 's/^/- /'
+              echo
+              echo "Markers use the \`zdiff3\` style: the common-ancestor base sits between \`|||||||\` and \`=======\`, so you can see fork vs. base vs. upstream."
+            else
+              echo "**A registered fork change disappeared during a clean text-merge:**"
+              echo '```'
+              cat /tmp/sentinel-report.txt
+              echo '```'
+              echo
+              echo "Upstream rewrote the surrounding code so git merged with no conflict but dropped the fork edit. Re-apply the fork change and its \`// FORK-SENTINEL:<id>\` marker."
+            fi
+            echo
+            echo "### How to resolve (safe for an agent given only this PR URL)"
+            echo "1. \`gh pr checkout <this PR number>\`"
+            echo "2. Resolve every conflict / re-apply the dropped edit. Preserve BOTH upstream's intent and the fork's. Never delete a \`FORK-SENTINEL:<id>\` marker."
+            echo "   - If \`.fork/UNRESOLVED-CONFLICTS.txt\` exists, those paths had **marker-less** conflicts (binary / modify-delete) auto-staged to one side — reconcile each, then **delete that file**."
+            echo "3. Commit and push. This PR is blocked from merging until: no conflict markers remain, no \`.fork/UNRESOLVED-CONFLICTS.txt\`, all fork sentinels are intact, and CI is green."
+            echo "4. **Merge with a merge commit — NOT squash or rebase.** This branch carries the 2-parent upstream merge commit; squashing or rebasing discards the upstream parent, so the same upstream commits get reprocessed and re-conflict on the next sync."
+            echo
+            echo "@coderabbitai ignore"
+          } > /tmp/pr-body.md
+
+          gh label create "$CONFLICT_LABEL" --color B60205 \
+            --description "Automated upstream sync needs resolution" 2>/dev/null || true
+          gh pr create --repo "$GITHUB_REPOSITORY" \
+            --base main --head "$CONFLICT_BRANCH" \
+            --title "Upstream Sync — Resolution Required ($REASON)" \
+            --body-file /tmp/pr-body.md \
+            --label "$CONFLICT_LABEL"
+          echo "result=conflict_pr" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger build workflow
+        if: steps.sync.outputs.result == 'merged'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           event-type: upstream-changes-merged
-
-      - name: Create PR for conflicted changes
-        if: steps.merge.outputs.result == 'conflicts'
-        run: |
-          BRANCH="upstream-sync-conflicts"
-          HEAD_REF="${GITHUB_REPOSITORY_OWNER}:${BRANCH}"
-          EXISTING_PR=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --base main \
-            --head "$BRANCH" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
-
-          git fetch origin "$BRANCH" || true
-          git branch -D "$BRANCH" 2>/dev/null || true
-          git checkout -B "$BRANCH" main
-          git merge upstream/main || true
-          CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | sed 's/^/- /')
-          git add -A
-          git commit -m "Upstream sync (conflicts to resolve)"
-          git push -u origin "$BRANCH" --force
-
-          BODY="This PR merges upstream changes that conflict with our fork.
-
-          **Files with conflict markers that need manual resolution:**
-          ${CONFLICTED_FILES}
-
-          Search for \`<<<<<<<\` in the changed files and resolve each conflict.
-
-          @coderabbitai ignore"
-
-          if [ -n "$EXISTING_PR" ]; then
-            echo "Open upstream sync PR already exists: #$EXISTING_PR, updated branch $BRANCH"
-            exit 0
-          fi
-
-          gh pr create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Upstream Sync (Conflicts to Resolve)" \
-            --body "$BODY" \
-            --base main \
-            --head "$HEAD_REF"
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,3 +170,13 @@ Multi-line imports count total character length across all lines. Consolidate va
 ## Formatting
 
 Fix all formatting lint errors (trailing spaces, tabs, newlines, indentation) using auto-fix when available. All TypeScript/ESLint warnings and errors **must** be resolved.
+
+---
+
+<!-- FORK-SENTINEL:claude-fork-pointer — fork guidance entrypoint; see .fork/README.md -->
+
+## Fork Conventions
+
+This repository is a fork with an active upstream. Read **`FORK.md`** before changing code. Most importantly: tag every inline edit to an upstream file with a `FORK-SENTINEL:<id>` comment and register it in `.fork/sentinels.tsv` — CI blocks merges that drop a sentinel or leave a conflict marker.
+
+Run checks the fast way (see `FORK.md` → "Running checks"): **never `npx eslint .`** — the type-aware config makes a full-repo lint take minutes; lint only changed files instead. Type-check needs the workspace packages built first, and a full-client `tsc` is not expected to be clean (pre-existing upstream debt).

--- a/FORK.md
+++ b/FORK.md
@@ -1,4 +1,4 @@
-# CLAUDE-FORK.md
+# Fork Guide
 
 Fork-specific guidance for AI coding assistants. For general project architecture, code style, and conventions, see [AGENTS.md](./AGENTS.md) (upstream-maintained).
 
@@ -11,6 +11,53 @@ LibreChat fork with active upstream. Minimize merge conflicts:
 - Custom backend routes go under `/api/forked/*`
 - Prefer extension over modification (wrap components, override CSS via higher specificity)
 - Leave inline comments explaining why a change was made
+- **Tag every inline upstream edit** with a `FORK-SENTINEL:<id>` comment and register it in `.fork/sentinels.tsv`. CI blocks merges to `main` that drop a registered sentinel or leave a conflict marker. See `.fork/README.md`.
+
+## Running checks (fast)
+
+**ESLint is the lint gate — but never run `npx eslint .`.** The config is type-aware
+(it builds a TypeScript program per file), so linting the whole repo takes minutes.
+Lint only changed files, exactly like CI (~10s):
+
+```bash
+git diff --name-only --diff-filter=ACMRTUXB HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' \
+  | grep -E '^(api|client|packages)/' \
+  | xargs -r npx eslint --no-error-on-unmatched-pattern --max-warnings=0
+```
+
+Single file: `npx eslint path/to/file.tsx` (add `--fix` to auto-fix).
+
+Lint the **entire fork codebase** (all fork-owned JS/TS dirs, uses the existing config, ~5s) — a good final check that doesn't depend on what the diff happens to touch:
+
+```bash
+npx eslint --no-error-on-unmatched-pattern --max-warnings=0 \
+  client/src/forked-code-custom api/server/forked-code
+```
+
+**Type-check.** Build the workspace packages first or the client sees stale
+cross-package types (parallel + cached; skips the heavy client app build):
+
+```bash
+npx turbo run build --filter='./packages/*'
+cd client && npx tsc --noEmit
+```
+
+CI type-gates differ by workspace:
+
+- **`packages/*` ARE strictly type-checked** (`backend-review.yml` runs `tsc --noEmit -p`
+  on each). If you change a package, keep it clean:
+  `npx tsc --noEmit -p packages/<name>/tsconfig.json`.
+- **The `client/` app is NOT type-checked in CI** — it ships via Vite/esbuild (no type
+  check) and is covered by ESLint + Jest. So `cd client && npx tsc --noEmit` always
+  reports pre-existing **upstream** type debt (tests, a11y, agents, etc.). That baseline
+  is not yours to fix — only ensure the files **you** changed add no *new* errors.
+
+In practice: ESLint on changed files is the lint gate; package `tsc` is the type gate;
+a green `tsc` over the whole `client/` app is not expected and not required.
+
+**Install:** `npm ci` — authoritative (`packageManager: npm`, CI uses it) and never
+rewrites a lockfile. Avoid `bun install`: upstream's `bun.lock` is stale, so bun
+rewrites it on every run (large spurious diff).
 
 ## Fork File Locations
 
@@ -58,7 +105,7 @@ Frontend → POST /api/agents/chat/LiteLLM
 
 ### Key Gotchas
 
-1. **`streamUsage` is disabled for custom providers** — `packages/api/src/agents/run.ts:276` sets `llmConfig.streamUsage = false` for all custom providers. We patched this to skip the override when `agent.endpoint` contains `'litellm'` (case-insensitive `includes` check). Without this, `usage_metadata` arrives as `undefined` and `response_metadata.usage` is `{}`.
+1. **`streamUsage` is disabled for custom providers** — `packages/api/src/agents/run.ts` sets `llmConfig.streamUsage = false` for custom providers unless `model_parameters.streamUsage` is explicitly set. The fork's `applyLiteLLMStreamUsage` (`api/server/forked-code/agents/applyLiteLLMStreamUsage.js`, called from `client.js` via the `FORK-SENTINEL:litellm-streamusage` edit) sets that opt-in for LiteLLM-endpoint agents so upstream skips the disable path. Without it, `usage_metadata` arrives as `undefined` and `response_metadata.usage` is `{}`. (This replaces the older inline `run.ts` patch.)
 
 2. **`tokenCount` is deleted before reaching frontend** — `BaseClient.js:810` does `delete responseMessage.tokenCount` after saving to DB. `syncResponseUsage` re-attaches it from `client.getStreamUsage()`.
 
@@ -70,10 +117,12 @@ Frontend → POST /api/agents/chat/LiteLLM
 
 6. **TypeScript packages need rebuild** — Changes to `packages/api/src/` require `npm run build:packages` before restart.
 
-### Upstream Files Modified (minimize these)
+### Upstream Files Modified
 
-- `packages/api/src/agents/run.ts:276` — Skip `streamUsage = false` for endpoints containing "litellm"
-- `api/server/controllers/agents/request.js` — Import and call `syncResponseUsage` (non-blocking persist)
+The canonical, CI-enforced list of every inline upstream edit lives in `.fork/sentinels.tsv` (each tagged with a `FORK-SENTINEL:<id>`). Do not keep a duplicate list here. LiteLLM-relevant edits:
+
+- `api/server/controllers/agents/client.js` — calls `applyLiteLLMStreamUsage(agents)` (opts LiteLLM agents into streamed usage).
+- `api/server/controllers/agents/request.js` — calls `syncResponseUsage` (non-persist + fire-and-forget persist).
 
 ### Fork Files for Cost Display
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -973,6 +973,7 @@ class AgentClient extends BaseClient {
         if (this.agentConfigs && this.agentConfigs.size > 0) {
           agents.push(...this.agentConfigs.values());
         }
+        // FORK-SENTINEL:litellm-streamusage — opt LiteLLM agents into streamUsage so createRun keeps streamed usage
         applyLiteLLMStreamUsage(agents);
 
         // TODO: needs to be added as part of AgentContext initialization

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -291,6 +291,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         };
 
         const response = await client.sendMessage(text, messageOptions);
+        // FORK-SENTINEL:sync-response-usage — set token/cost usage on the response before the final SSE event
         await syncResponseUsage({ client, response });
 
         const messageId = response.messageId;
@@ -304,7 +305,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         const conversation = { ...convoData };
         conversation.title =
           conversation && !conversation.title ? null : conversation?.title || 'New Chat';
-        // Fire-and-forget: enrich with cost metadata and persist to DB without blocking the SSE final event.
+        // FORK-SENTINEL:sync-response-usage-persist — background-persist cost metadata without blocking the SSE final event
         // Token counts are already set on the response from the non-persist call above.
         syncResponseUsage({ client, response, req, persist: true }).catch((error) => {
           logger.warn('[ResumableAgentController] Background usage sync failed', {

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -223,7 +223,7 @@ const startServer = async () => {
   app.use('/api/mcp', routes.mcp);
   app.use('/api/rum', routes.rum);
 
-  // Initialize forked code routes and extensions
+  // FORK-SENTINEL:init-forked-code — mount forked-code routes/extensions onto the Express app
   initForkedCode(app);
   app.use('/metrics', metricsRouter);
 

--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <!-- FORK-SENTINEL:brand-title — fork branding (page title + meta description) -->
     <meta name="description" content="Daniel AI - We speak human (with a little AI magic)" />
     <title>Daniel AI</title>
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png" />

--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -130,6 +130,7 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
       margin = 'mb-12';
     }
 
+    // FORK-SENTINEL:landing-suggestions-margin — extra bottom margin so PromptSuggestions clears the input
     if (contentHeight > 334) {
       margin = 'mb-28';
       if (window.innerWidth < 640) {
@@ -211,6 +212,7 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
             {description}
           </div>
         )}
+        {/* FORK-SENTINEL:prompt-suggestions — fork-only starter prompt suggestions on the landing screen */}
         <PromptSuggestions />
       </div>
     </div>

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -52,11 +52,12 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
           {spec.description && (
             <span className="break-words text-xs font-normal">{spec.description}</span>
           )}
+          {/* FORK-SENTINEL:modelspec-badges — fork-only model badges under the spec description */}
           <ModelBadges spec={spec} />
         </div>
       </div>
 
-      {/* Wrapper for capability icons and selected checkmark, aligned to top */}
+      {/* FORK-SENTINEL:modelspec-capabilities — fork-only capability icons aligned to the spec row top */}
       <div
         className="flex flex-shrink-0 gap-2 py-1"
         style={{ alignSelf: 'flex-start', marginRight: isSelected ? '0' : '24px' }}

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -84,15 +84,17 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                   {spec.description && (
                     <span className="break-words text-xs font-normal">{spec.description}</span>
                   )}
-                  <ModelBadges
-                    spec={spec}
-                  />
+                  {/* FORK-SENTINEL:searchresults-badges — fork-only model badges in endpoint search results */}
+                  <ModelBadges spec={spec} />
                 </div>
               </div>
-              {/* Wrapper for capability icons and selected checkmark, aligned to top */}
+              {/* FORK-SENTINEL:searchresults-capabilities — fork-only capability icons in endpoint search results */}
               <div
                 className="flex flex-shrink-0 gap-2 py-1"
-                style={{ alignSelf: 'flex-start', marginRight: selectedSpec === spec.name ? '0' : '24px' }}
+                style={{
+                  alignSelf: 'flex-start',
+                  marginRight: selectedSpec === spec.name ? '0' : '24px',
+                }}
               >
                 <CapabilityIcons capabilities={spec.iconCapabilities} />
               </div>
@@ -263,4 +265,3 @@ export function renderSearchResults(
     />
   );
 }
-

--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -260,7 +260,7 @@ const HoverButtons = ({
         />
       )}
 
-      {/* Response Cost */}
+      {/* FORK-SENTINEL:response-cost — fork-only per-message cost display */}
       <ResponseCost message={message} conversation={conversation} isLast={isLast} />
 
       {/* Continue Button */}

--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -87,6 +87,7 @@ function AccountSettings({ collapsed = false }: { collapsed?: boolean }) {
           <GearIcon className="icon-md" aria-hidden="true" />
           {localize('com_nav_settings')}
         </Menu.MenuItem>
+        {/* FORK-SENTINEL:customer-portal-menu — fork-only billing portal entry in the account menu */}
         <CustomerPortalMenuItem email={user?.email} />
         <DropdownMenuSeparator />
         <Menu.MenuItem onClick={() => logout()} className="select-item text-sm">

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -15,6 +15,7 @@ const root = createRoot(container);
 
 root.render(
   <ApiErrorBoundaryProvider>
+    {/* FORK-SENTINEL:forked-customizations — mounts fork-only global customizations (and custom CSS import above) */}
     <ForkedCustomizations />
     <App />
   </ApiErrorBoundaryProvider>,

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -26,6 +26,7 @@ import { RouteGuard } from '~/forked-code-custom';
 const AuthLayout = () => (
   <AuthContextProvider>
     <WithRum>
+      {/* FORK-SENTINEL:route-guard — fork-only auth/subscription route gating around app routes */}
       <RouteGuard>
         <Outlet />
       </RouteGuard>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig(({ command }) => ({
       },
       includeAssets: [],
       manifest: {
+        // FORK-SENTINEL:brand-manifest — PWA manifest fork branding (name + short_name)
         name: 'Daniel AI',
         short_name: 'Daniel AI',
         display: 'standalone',


### PR DESCRIPTION
## What

Adds the fork's upstream-sync integrity system: a sentinel registry + verifier + CI guards that turn a silently-dropped fork edit (during an automated upstream merge) into a loud, blocking failure, plus the fork customizations the guard protects.

## How it works

**Sentinel system**
- `.fork/sentinels.tsv` — registry of every inline upstream edit. Each is tagged in code with a `FORK-SENTINEL:<id>` marker and a **code anchor** (the fork behavior that must survive a merge).
- `.fork/verify-sentinels.sh` — asserts each marker is present, each anchor is present and **unique** (exactly one line, so a partial drop can't hide behind a sibling line), and no unregistered/orphan markers exist. `SKIP_ORPHAN_SCAN` runs pass 1 only, for verifying a *foreign* registry (the base registry over a PR tree).
- `.fork/README.md` — registry conventions.

**CI guards**
- `sync-pr-guard.yml` (required check on PRs into `main`): rejects conflict markers, blocks on the **existence** (`-e`) of an unresolved marker-less conflict artifact, verifies the **base** registry intact over the PR tree (catches a PR that drops an edit and repurposes its row under the same id), then validates the PR registry end-to-end. Verifier logic is pinned to `base` so a PR can't neuter its own gate.
- `sync-upstream.yml`: hourly merge; verifies sentinels on clean text-merges and escalates dropped sentinels/conflicts to a resolution PR.

**Docs**: `FORK.md` (renamed from `CLAUDE-FORK.md`) + `CLAUDE.md` pointer.

**Customizations** (each `FORK-SENTINEL`-tagged): LiteLLM `streamUsage` opt-in; response token/cost usage sync + per-message cost display; PWA/page branding; landing prompt suggestions; model badges + capability icons; customer portal menu; route guard; forked-code mount.

## Verification

- `bash .fork/verify-sentinels.sh` passes (17 registered, anchors unique, no orphans).
- Verifier behaviors proven via negative tests: ambiguous (substring) anchor fails; a dropped fork edit fails; `SKIP_ORPHAN_SCAN` correctly skips the orphan scan.
- `bash -n` clean on the verifier and all three workflow `run:` blocks; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
