### PR TITLE
fix: persist LiteLLM usage snapshot so cost breakdown survives refresh

### DIFF
--- a/api/server/forked-code/agents/syncResponseUsage.db.spec.js
+++ b/api/server/forked-code/agents/syncResponseUsage.db.spec.js
@@ -1,0 +1,82 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const mockGetLiteLLMModelInfoMap = jest.fn().mockResolvedValue({
+  'claude-fable-5': {
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+  },
+});
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('~/cache/getLogStores', () => jest.fn(() => ({ get: jest.fn(), set: jest.fn() })));
+
+jest.mock('~/server/forked-code/litellm/modelInfoCache', () => ({
+  getLiteLLMModelInfoMap: (...args) => mockGetLiteLLMModelInfoMap(...args),
+}));
+
+require('~/db/models');
+const { getMessages } = require('~/models');
+const { syncResponseUsage } = require('./syncResponseUsage');
+
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await mongoose.connection.dropDatabase();
+  jest.clearAllMocks();
+});
+
+describe('syncResponseUsage (database-backed)', () => {
+  it('persists the usage snapshot so it survives a fresh read from the database', async () => {
+    const conversationId = '11111111-1111-4111-8111-111111111111';
+    const messageId = '22222222-2222-4222-8222-222222222222';
+    const userId = '33333333-3333-4333-8333-333333333333';
+
+    const response = {
+      messageId,
+      conversationId,
+      model: 'claude-fable-5',
+      metadata: {},
+    };
+    const usage = {
+      total_tokens: 3506,
+      prompt_tokens: 263,
+      completion_tokens: 3243,
+      completion_tokens_details: { reasoning_tokens: 274 },
+    };
+
+    await syncResponseUsage({
+      client: { getStreamUsage: () => usage, collectedUsage: [usage] },
+      response,
+      req: { user: { id: userId }, body: {}, config: {} },
+      persist: true,
+    });
+
+    const [persisted] = await getMessages({ conversationId, user: userId });
+
+    expect(persisted).toBeDefined();
+    expect(persisted.tokenCount).toBe(3243);
+    expect(persisted.metadata?.forked_litellm_usage).toEqual(
+      expect.objectContaining({
+        input_tokens: 263,
+        output_tokens: 3243,
+        reasoning_tokens: 274,
+        model: 'claude-fable-5',
+      }),
+    );
+  });
+});

--- a/api/server/forked-code/agents/syncResponseUsage.js
+++ b/api/server/forked-code/agents/syncResponseUsage.js
@@ -346,7 +346,11 @@ async function syncResponseUsage({ client, response, req, persist = false }) {
 
   try {
     await saveMessage(
-      req,
+      {
+        userId: req.user?.id,
+        isTemporary: req.body?.isTemporary,
+        interfaceConfig: req.config?.interfaceConfig,
+      },
       {
         messageId: response.messageId,
         conversationId: response.conversationId,

--- a/api/server/forked-code/agents/syncResponseUsage.spec.js
+++ b/api/server/forked-code/agents/syncResponseUsage.spec.js
@@ -111,7 +111,7 @@ describe('syncResponseUsage', () => {
         reasoning: reasoningTokens * 0.000015,
       });
       expect(mockSaveMessage).toHaveBeenCalledWith(
-        expect.anything(),
+        expect.objectContaining({ userId: 'user-1' }),
         expect.objectContaining({
           messageId: 'message-1',
           conversationId: 'conversation-1',

--- a/client/src/forked-code-custom/currencyAdapter.ts
+++ b/client/src/forked-code-custom/currencyAdapter.ts
@@ -5,7 +5,7 @@ let usdToNokRatePromise: Promise<number | null> | null = null;
 
 const CACHE_DURATION_MS = 60 * 60 * 1000;
 const FAILURE_BACKOFF_MS = 60_000;
-const USD_TO_NOK_ENDPOINT = 'https://api.frankfurter.app/latest?from=USD&to=NOK';
+const USD_TO_NOK_ENDPOINT = 'https://api.frankfurter.dev/v1/latest?from=USD&to=NOK';
 
 export const fetchUsdToNokRate = async (): Promise<number | null> => {
   const now = Date.now();


### PR DESCRIPTION
## Problem

After PR #38, the cost breakdown showed input + output + reasoning tokens while the message was live, but after a **page refresh** it lost everything except output tokens.

## Root cause

In `syncResponseUsage.js`, the background persist call passed the Express `req` as the first argument to `saveMessage`:

```js
await saveMessage(req, { ...metadata... }, { context }); // ❌
```

But the data-schemas `saveMessage` expects `{ userId, isTemporary, interfaceConfig }` and starts with `if (!userId) throw new Error('User not authenticated')`. Since `req.userId` is `undefined` (it's `req.user.id`), **every persist call threw** — and the error was swallowed by `syncResponseUsage`'s own `try/catch` as a `logger.warn`. The `forked_litellm_usage` snapshot was never written to MongoDB.

- **Live:** the non-persist call mutates `response.metadata` in memory for the SSE event → all tokens render. ✅
- **After refresh:** the message is re-read from the DB without the snapshot → falls back to persisted `tokenCount` (output only); input + reasoning lost. ❌

The existing spec missed this because it fully mocks `saveMessage` and asserted the first arg with `expect.anything()`.

## Changes

- **Fix:** pass the correct `{ userId, isTemporary, interfaceConfig }` context to `saveMessage`, matching every other caller in the controller.
- **Regression (unit):** tighten the mocked spec assertion to verify the `userId` context — fails against the old buggy call.
- **Regression (integration):** new database-backed spec that persists through the real `saveMessage` into an in-memory MongoDB and re-reads via `getMessages`, proving the snapshot survives the round-trip (the "after refresh" path).
- **Currency:** swap the USD/NOK endpoint from the deprecated `api.frankfurter.app` (now a CORS-less 301 redirect) to `api.frankfurter.dev`, restoring live NOK rates.

All changes are confined to `forked-code` / `forked-code-custom` — no upstream files modified.

## Verification

```
PASS  syncResponseUsage.spec.js        (12 mocked unit tests)
PASS  syncResponseUsage.db.spec.js     (1 real-DB round-trip test)
Tests: 13 passed, 13 total
```
Lint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)