### PR TITLE
fix: correct doubled LiteLLM token counts and drop internal margin from cost breakdown

### DIFF
--- a/api/server/forked-code/agents/modelEndHandlerUsage.spec.js
+++ b/api/server/forked-code/agents/modelEndHandlerUsage.spec.js
@@ -1,5 +1,5 @@
 jest.mock('@librechat/data-schemas', () => ({
-  logger: { error: jest.fn(), debug: jest.fn() },
+  logger: { error: jest.fn(), debug: jest.fn(), warn: jest.fn() },
 }));
 
 jest.mock(
@@ -40,6 +40,7 @@ jest.mock('~/server/services/Files/process', () => ({
 }));
 
 const { ModelEndHandler } = require('../../controllers/agents/callbacks');
+const { logger } = require('@librechat/data-schemas');
 const { preserveLiteLLMUsage } = require('./preserveLiteLLMUsage');
 
 const buildGraph = ({ endpoint } = {}) => ({
@@ -54,6 +55,10 @@ const preserveForLiteLLM = (handler) =>
   preserveLiteLLMUsage({ on_chat_model_end: handler }, { endpoint: 'LiteLLM' });
 
 describe('ModelEndHandler LiteLLM usage preservation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('preserves OpenAI-compatible response usage details omitted from usage_metadata', async () => {
     const collectedUsage = [];
     const handler = new ModelEndHandler(collectedUsage, null);
@@ -167,6 +172,179 @@ describe('ModelEndHandler LiteLLM usage preservation', () => {
         output_tokens: 96,
         total_tokens: 264,
       }),
+    );
+  });
+
+  it('normalizes duplicate raw stream usage before preserving LiteLLM details', async () => {
+    const collectedUsage = [];
+    const handler = new ModelEndHandler(collectedUsage, null);
+    preserveForLiteLLM(handler);
+
+    await handler.handle(
+      'on_chat_model_end',
+      {
+        output: {
+          id: 'chatcmpl-5cc4ed6a-16d3-40c0-b845-877b40339b0a',
+          usage_metadata: {
+            input_tokens: 263,
+            output_tokens: 2531,
+            total_tokens: 2794,
+            input_token_details: {
+              cache_read: 0,
+              cache_creation: 0,
+            },
+            output_token_details: {
+              reasoning: 18,
+            },
+          },
+          response_metadata: {
+            usage: {
+              prompt_tokens: 526,
+              completion_tokens: 5062,
+              total_tokens: 5588,
+              prompt_tokens_details: {
+                text_tokens: 526,
+                cached_tokens: 0,
+                cache_creation_tokens: 0,
+              },
+              completion_tokens_details: {
+                text_tokens: 5026,
+                reasoning_tokens: 36,
+              },
+            },
+          },
+        },
+      },
+      { ls_model_name: 'claude-opus-4-8-reasoning', user_id: 'u' },
+      buildGraph(),
+    );
+
+    expect(collectedUsage[0]).toEqual(
+      expect.objectContaining({
+        input_tokens: 263,
+        output_tokens: 2531,
+        total_tokens: 2794,
+        output_token_details: {
+          reasoning: 18,
+        },
+        prompt_tokens_details: {
+          text_tokens: 263,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        completion_tokens_details: {
+          text_tokens: 2513,
+          reasoning_tokens: 18,
+        },
+      }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[preserveLiteLLMUsage] Normalized duplicated raw stream usage',
+      { multiplier: 2 },
+    );
+  });
+
+  it('keeps complete normalized usage when raw stream counts are an inconsistent near-duplicate', async () => {
+    const collectedUsage = [];
+    const handler = new ModelEndHandler(collectedUsage, null);
+    preserveForLiteLLM(handler);
+
+    await handler.handle(
+      'on_chat_model_end',
+      {
+        output: {
+          usage_metadata: {
+            input_tokens: 263,
+            output_tokens: 2531,
+            total_tokens: 2794,
+            output_token_details: {
+              reasoning: 18,
+            },
+          },
+          response_metadata: {
+            usage: {
+              prompt_tokens: 525,
+              completion_tokens: 5062,
+              total_tokens: 5587,
+              prompt_tokens_details: {
+                text_tokens: 525,
+              },
+              completion_tokens_details: {
+                text_tokens: 5026,
+                reasoning_tokens: 36,
+              },
+            },
+          },
+        },
+      },
+      { ls_model_name: 'claude-opus-4-8-reasoning', user_id: 'u' },
+      buildGraph(),
+    );
+
+    expect(collectedUsage[0]).toEqual(
+      expect.objectContaining({
+        input_tokens: 263,
+        output_tokens: 2531,
+        total_tokens: 2794,
+        output_token_details: {
+          reasoning: 18,
+        },
+      }),
+    );
+    expect(collectedUsage[0].prompt_tokens_details).toBeUndefined();
+    expect(collectedUsage[0].completion_tokens_details).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[preserveLiteLLMUsage] Ignored inconsistent raw stream usage',
+      {
+        normalized: { input: 263, output: 2531, total: 2794 },
+        raw: { input: 525, output: 5062, total: 5587 },
+      },
+    );
+  });
+
+  it('keeps complete normalized usage when partial raw stream counts disagree', async () => {
+    const collectedUsage = [];
+    const handler = new ModelEndHandler(collectedUsage, null);
+    preserveForLiteLLM(handler);
+
+    await handler.handle(
+      'on_chat_model_end',
+      {
+        output: {
+          usage_metadata: {
+            input_tokens: 263,
+            output_tokens: 2531,
+            total_tokens: 2794,
+          },
+          response_metadata: {
+            usage: {
+              prompt_tokens: 525,
+              completion_tokens: 5062,
+              completion_tokens_details: {
+                reasoning_tokens: 36,
+              },
+            },
+          },
+        },
+      },
+      { ls_model_name: 'claude-opus-4-8-reasoning', user_id: 'u' },
+      buildGraph(),
+    );
+
+    expect(collectedUsage[0]).toEqual(
+      expect.objectContaining({
+        input_tokens: 263,
+        output_tokens: 2531,
+        total_tokens: 2794,
+      }),
+    );
+    expect(collectedUsage[0].completion_tokens_details).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[preserveLiteLLMUsage] Ignored inconsistent raw stream usage',
+      {
+        normalized: { input: 263, output: 2531, total: 2794 },
+        raw: { input: 525, output: 5062, total: null },
+      },
     );
   });
 

--- a/api/server/forked-code/agents/preserveLiteLLMUsage.js
+++ b/api/server/forked-code/agents/preserveLiteLLMUsage.js
@@ -1,9 +1,63 @@
+const { logger } = require('@librechat/data-schemas');
+
 const hasUsageValue = (value) => value != null && Number.isFinite(Number(value));
 const isPositiveUsageValue = (value) => hasUsageValue(value) && Number(value) > 0;
 
-const shouldUseRawCount = (currentValue, rawValue) =>
-  isPositiveUsageValue(rawValue) &&
-  (!isPositiveUsageValue(currentValue) || Number(currentValue) !== Number(rawValue));
+const getRawUsageMultiplier = (usage, rawUsage) => {
+  const comparableCounts = [
+    [usage?.input_tokens, rawUsage?.prompt_tokens],
+    [usage?.output_tokens, rawUsage?.completion_tokens],
+    [usage?.total_tokens, rawUsage?.total_tokens],
+  ].filter(([currentValue, rawValue]) => {
+    return isPositiveUsageValue(currentValue) && isPositiveUsageValue(rawValue);
+  });
+
+  if (comparableCounts.length < 2) {
+    return 1;
+  }
+
+  const multiplier = Number(comparableCounts[0][1]) / Number(comparableCounts[0][0]);
+  if (!Number.isInteger(multiplier) || multiplier < 2) {
+    return 1;
+  }
+
+  return comparableCounts.every(
+    ([currentValue, rawValue]) => Number(rawValue) === Number(currentValue) * multiplier,
+  )
+    ? multiplier
+    : 1;
+};
+
+const divideNumericUsageValues = (value, divisor) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value / divisor;
+  }
+  if (Array.isArray(value)) {
+    return value.map((nestedValue) => divideNumericUsageValues(nestedValue, divisor));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        divideNumericUsageValues(nestedValue, divisor),
+      ]),
+    );
+  }
+  return value;
+};
+
+const normalizeRawUsage = (usage, rawUsage) => {
+  const multiplier = getRawUsageMultiplier(usage, rawUsage);
+  if (multiplier > 1) {
+    logger.debug('[preserveLiteLLMUsage] Normalized duplicated raw stream usage', {
+      multiplier,
+    });
+  }
+  return {
+    multiplier,
+    usage: multiplier > 1 ? divideNumericUsageValues(rawUsage, multiplier) : rawUsage,
+  };
+};
 
 const isLiteLLMEndpoint = (endpoint) =>
   typeof endpoint === 'string' && endpoint.toLowerCase().includes('litellm');
@@ -25,36 +79,133 @@ const getRawCacheCreationTokens = (rawUsage) =>
   rawUsage?.prompt_tokens_details?.cache_write_tokens ??
   rawUsage?.cache_creation_input_tokens;
 
+const getRawReasoningTokens = (rawUsage) =>
+  rawUsage?.completion_tokens_details?.reasoning_tokens ??
+  rawUsage?.output_token_details?.reasoning ??
+  rawUsage?.output_token_details?.reasoning_tokens;
+
+const toUsageNumber = (value) => (hasUsageValue(value) ? Number(value) : null);
+
+const getComparableUsageCounts = (usage, rawUsage) => ({
+  current: {
+    input: toUsageNumber(usage?.input_tokens),
+    output: toUsageNumber(usage?.output_tokens),
+    total: toUsageNumber(usage?.total_tokens),
+  },
+  raw: {
+    input: toUsageNumber(rawUsage?.prompt_tokens),
+    output: toUsageNumber(rawUsage?.completion_tokens),
+    total: toUsageNumber(rawUsage?.total_tokens),
+  },
+});
+
+const hasCompleteCounts = ({ input, output, total }) =>
+  isPositiveUsageValue(input) &&
+  isPositiveUsageValue(output) &&
+  isPositiveUsageValue(total) &&
+  total === input + output;
+
+const availableRawCountsMatch = ({ current, raw }) =>
+  Object.keys(raw).every((key) => {
+    return !isPositiveUsageValue(raw[key]) || current[key] === raw[key];
+  });
+
+const isReasoningInclusiveRepair = (usage, rawUsage, counts) => {
+  const reasoningTokens = Number(
+    usage?.output_token_details?.reasoning ??
+      usage?.output_token_details?.reasoning_tokens ??
+      getRawReasoningTokens(rawUsage),
+  );
+
+  return (
+    isPositiveUsageValue(reasoningTokens) &&
+    hasCompleteCounts(counts.current) &&
+    hasCompleteCounts(counts.raw) &&
+    counts.current.input === counts.raw.input &&
+    counts.current.output + reasoningTokens === counts.raw.output
+  );
+};
+
+const shouldTrustRawUsage = (usage, rawUsage, multiplier) => {
+  if (multiplier > 1) {
+    return true;
+  }
+
+  const counts = getComparableUsageCounts(usage, rawUsage);
+  const currentComplete = hasCompleteCounts(counts.current);
+
+  if (!currentComplete) {
+    return true;
+  }
+  if (availableRawCountsMatch(counts)) {
+    return true;
+  }
+  if (isReasoningInclusiveRepair(usage, rawUsage, counts)) {
+    return true;
+  }
+
+  logger.warn('[preserveLiteLLMUsage] Ignored inconsistent raw stream usage', {
+    normalized: counts.current,
+    raw: counts.raw,
+  });
+  return false;
+};
+
+const mergeRawCount = (currentValue, rawValue, trustRawUsage) => {
+  if (!isPositiveUsageValue(rawValue)) {
+    return currentValue;
+  }
+  if (!isPositiveUsageValue(currentValue) || trustRawUsage) {
+    return rawValue;
+  }
+  return currentValue;
+};
+
 const mergeOpenAICompatibleUsage = (usage, rawUsage) => {
   if (!rawUsage || typeof rawUsage !== 'object') {
     return usage;
   }
 
+  // LangChain adds numeric response metadata when provider and synthetic usage chunks are merged.
+  const normalized = normalizeRawUsage(usage, rawUsage);
+  const normalizedRawUsage = normalized.usage;
+  const trustRawUsage = shouldTrustRawUsage(usage, normalizedRawUsage, normalized.multiplier);
   const merged = { ...(usage ?? {}) };
-  if (shouldUseRawCount(merged.input_tokens, rawUsage.prompt_tokens)) {
-    merged.input_tokens = rawUsage.prompt_tokens;
+  merged.input_tokens = mergeRawCount(
+    merged.input_tokens,
+    normalizedRawUsage.prompt_tokens,
+    trustRawUsage,
+  );
+  merged.output_tokens = mergeRawCount(
+    merged.output_tokens,
+    normalizedRawUsage.completion_tokens,
+    trustRawUsage,
+  );
+  merged.total_tokens = mergeRawCount(
+    merged.total_tokens,
+    normalizedRawUsage.total_tokens,
+    trustRawUsage,
+  );
+
+  if (!trustRawUsage) {
+    return merged;
   }
-  if (shouldUseRawCount(merged.output_tokens, rawUsage.completion_tokens)) {
-    merged.output_tokens = rawUsage.completion_tokens;
-  }
-  if (shouldUseRawCount(merged.total_tokens, rawUsage.total_tokens)) {
-    merged.total_tokens = rawUsage.total_tokens;
-  }
-  if (rawUsage.prompt_tokens_details != null) {
+
+  if (normalizedRawUsage.prompt_tokens_details != null) {
     merged.prompt_tokens_details = {
-      ...rawUsage.prompt_tokens_details,
+      ...normalizedRawUsage.prompt_tokens_details,
       ...(merged.prompt_tokens_details ?? {}),
     };
   }
-  if (rawUsage.completion_tokens_details != null) {
+  if (normalizedRawUsage.completion_tokens_details != null) {
     merged.completion_tokens_details = {
-      ...rawUsage.completion_tokens_details,
+      ...normalizedRawUsage.completion_tokens_details,
       ...(merged.completion_tokens_details ?? {}),
     };
   }
 
-  const cacheRead = getRawCacheReadTokens(rawUsage);
-  const cacheCreation = getRawCacheCreationTokens(rawUsage);
+  const cacheRead = getRawCacheReadTokens(normalizedRawUsage);
+  const cacheCreation = getRawCacheCreationTokens(normalizedRawUsage);
   if (isPositiveUsageValue(cacheRead) || isPositiveUsageValue(cacheCreation)) {
     merged.input_token_details = {
       ...(merged.input_token_details ?? {}),

--- a/api/server/forked-code/routes/litellm.js
+++ b/api/server/forked-code/routes/litellm.js
@@ -65,39 +65,4 @@ router.get('/model-info', requireJwtAuth, async (req, res) => {
   }
 });
 
-/**
- * Proxy endpoint to fetch cost margin config from LiteLLM
- *
- * @route GET /api/forked/litellm/cost-margin
- * @returns {object} { margin: number } — global margin as a decimal (e.g. 0.15 = 15%)
- */
-router.get('/cost-margin', requireJwtAuth, async (req, res) => {
-  try {
-    const apiKey = process.env.LITELLM_API_KEY;
-
-    if (!apiKey) {
-      return res.json({ margin: 0 });
-    }
-
-    const baseURL = process.env.LITELLM_BASE_URL || 'https://litellm.danieldjupvik.com';
-    const response = await axios.get(`${baseURL}/config/cost_margin_config`, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      timeout: 5000,
-    });
-
-    const globalMargin = response.data?.values?.global;
-    const margin =
-      typeof globalMargin === 'number' && Number.isFinite(globalMargin) ? globalMargin : 0;
-
-    res.setHeader('Cache-Control', 'public, max-age=3600');
-    return res.json({ margin });
-  } catch (error) {
-    logger.error('Error fetching LiteLLM cost margin config:', error?.message);
-    return res.status(502).json({ error: 'Failed to fetch cost margin config' });
-  }
-});
-
 module.exports = router;

--- a/client/src/forked-code-custom/ResponseCost.spec.ts
+++ b/client/src/forked-code-custom/ResponseCost.spec.ts
@@ -90,4 +90,31 @@ describe('ResponseCost snapshot breakdown', () => {
       }),
     );
   });
+
+  it('splits LiteLLM completion tokens into visible output and reasoning at base rates', () => {
+    const breakdown = buildBreakdownFromRates({
+      model: 'claude-opus-4-8-reasoning',
+      inputTokens: 263,
+      outputTokens: 2531,
+      reasoningTokens: 18,
+      rates: {
+        input_cost_per_token: 5 / 1_000_000,
+        output_cost_per_token: 25 / 1_000_000,
+      },
+      lockedRates: true,
+    });
+
+    expect(breakdown).toEqual(
+      expect.objectContaining({
+        inputTokens: 263,
+        outputTokens: 2531,
+        effectiveOutputTokens: 2513,
+        reasoningTokens: 18,
+      }),
+    );
+    expect(breakdown.inputCost).toBeCloseTo(0.001315, 12);
+    expect(breakdown.outputCost).toBeCloseTo(0.062825, 12);
+    expect(breakdown.reasoningCost).toBeCloseTo(0.00045, 12);
+    expect(breakdown.totalCost).toBeCloseTo(0.06459, 12);
+  });
 });

--- a/client/src/forked-code-custom/ResponseCost.tsx
+++ b/client/src/forked-code-custom/ResponseCost.tsx
@@ -21,7 +21,7 @@ import {
   buildBreakdownFromModelInfo,
   buildBreakdownFromSnapshot,
 } from './pricing';
-import { fetchLiteLLMModelInfo, fetchCostMargin } from './litellmInfoAdapter';
+import { fetchLiteLLMModelInfo } from './litellmInfoAdapter';
 import { fetchUsdToNokRate } from './currencyAdapter';
 import { useGetStartupConfig } from '~/data-provider';
 import { cn } from '../utils';
@@ -186,7 +186,6 @@ const ResponseCost = ({ message, conversation, isLast }: ResponseCostProps) => {
   const [displayCurrencyPreference, setDisplayCurrencyPreference] =
     useState<SupportedCurrency>('USD');
   const [usdToNokRate, setUsdToNokRate] = useState<number | null>(null);
-  const [costMargin, setCostMargin] = useState(0);
   const calculationComplete = useRef(false);
   const { data: startupConfig } = useGetStartupConfig();
   const queryClient = useQueryClient();
@@ -224,15 +223,7 @@ const ResponseCost = ({ message, conversation, isLast }: ResponseCostProps) => {
       }
     };
 
-    const getMargin = async () => {
-      const margin = await fetchCostMargin();
-      if (isMounted) {
-        setCostMargin(margin);
-      }
-    };
-
     getCurrencyRate();
-    getMargin();
 
     return () => {
       isMounted = false;
@@ -514,14 +505,12 @@ const ResponseCost = ({ message, conversation, isLast }: ResponseCostProps) => {
     [baseCurrency, displayCurrency, usdToNokRate],
   );
 
-  const marginMultiplier = 1 + costMargin;
-
   const displayedTotalCost = useMemo(() => {
     if (!breakdown) {
       return 0;
     }
-    return convertForDisplay(breakdown.totalCost * marginMultiplier, baseCurrency);
-  }, [breakdown, baseCurrency, convertForDisplay, marginMultiplier]);
+    return convertForDisplay(breakdown.totalCost, baseCurrency);
+  }, [breakdown, baseCurrency, convertForDisplay]);
 
   const handleCurrencyPreferenceChange = useCallback((value: string) => {
     setDisplayCurrencyPreference(value === 'NOK' ? 'NOK' : 'USD');
@@ -541,12 +530,12 @@ const ResponseCost = ({ message, conversation, isLast }: ResponseCostProps) => {
       return null;
     }
     return convertCurrency({
-      amount: breakdown.totalCost * marginMultiplier,
+      amount: breakdown.totalCost,
       from: baseCurrency,
       to: 'USD',
       usdToNokRate,
     });
-  }, [breakdown, baseCurrency, usdToNokRate, marginMultiplier]);
+  }, [breakdown, baseCurrency, usdToNokRate]);
 
   const claudeCost = useMemo(() => {
     if (!breakdown || !claudeRates || breakdownTotalInUsd == null) return null;
@@ -579,10 +568,7 @@ const ResponseCost = ({ message, conversation, isLast }: ResponseCostProps) => {
     return null;
   }
 
-  const compactCostDisplay = formatCurrencyValue(
-    breakdown.totalCost * marginMultiplier,
-    baseCurrency,
-  );
+  const compactCostDisplay = formatCurrencyValue(breakdown.totalCost, baseCurrency);
   const unitLabel = displayCurrency === 'USD' ? '$1' : '1 NOK';
   const showingFallbackCurrency =
     displayCurrencyPreference === 'NOK' &&
@@ -716,7 +702,7 @@ const ResponseCost = ({ message, conversation, isLast }: ResponseCostProps) => {
                 </div>
                 <span className="font-mono text-sm">
                   {formatCurrencyValue(
-                    convertForDisplay(row.cost * marginMultiplier, baseCurrency),
+                    convertForDisplay(row.cost, baseCurrency),
                     displayCurrency,
                     true,
                   )}

--- a/client/src/forked-code-custom/litellmInfoAdapter.ts
+++ b/client/src/forked-code-custom/litellmInfoAdapter.ts
@@ -44,6 +44,7 @@ export interface LiteLLMModelInfo {
   input_cost_per_token_batches?: number | null;
   output_cost_per_token_batches?: number | null;
   output_cost_per_token?: number;
+  output_cost_per_reasoning_token?: number | null;
   output_cost_per_audio_token?: number | null;
   output_cost_per_character?: number | null;
   output_cost_per_token_above_128k_tokens?: number | null;
@@ -93,10 +94,6 @@ export interface ModelPricingInfo {
 let modelInfoCache: Record<string, LiteLLMModelInfo> | null = null;
 let lastFetchTime = 0;
 const CACHE_DURATION = 60 * 60 * 1000; // Cache for 1 hour
-
-let marginCache: number | null = null;
-let marginFetchTime = 0;
-let marginInflight: Promise<number> | null = null;
 
 // Singleton promise for initialization
 let globalLiteLLMDataPromise: Promise<Record<string, LiteLLMModelInfo>> | null = null;
@@ -151,43 +148,6 @@ export const fetchLiteLLMModelInfo = async (): Promise<Record<string, LiteLLMMod
     // Return empty object if fetch fails
     return {};
   }
-};
-
-/**
- * Fetch the global cost margin from LiteLLM (cached for 1 hour)
- */
-export const fetchCostMargin = async (): Promise<number> => {
-  const now = Date.now();
-
-  if (marginCache != null && now - marginFetchTime < CACHE_DURATION) {
-    return marginCache;
-  }
-
-  if (marginInflight) {
-    return marginInflight;
-  }
-
-  const authHeader = axios.defaults.headers.common['Authorization'] as string | undefined;
-  marginInflight = fetch('/api/forked/litellm/cost-margin', {
-    headers: authHeader ? { Authorization: authHeader } : {},
-  })
-    .then(async (res) => {
-      if (!res.ok) {
-        return 0;
-      }
-      const data = (await res.json()) as { margin?: number };
-      const margin =
-        typeof data.margin === 'number' && Number.isFinite(data.margin) ? data.margin : 0;
-      marginCache = margin;
-      marginFetchTime = Date.now();
-      return margin;
-    })
-    .catch(() => 0)
-    .finally(() => {
-      marginInflight = null;
-    });
-
-  return marginInflight;
 };
 
 /**


### PR DESCRIPTION
## Problem

The cost breakdown displayed roughly **2.3× the real cost** of a message — two independent bugs stacked on top of each other.

Example (174 prompt / 1266 completion / 656 reasoning, true cost $0.01554):
- UI showed input 348, output 2532, total **$0.03636**.

## Bug 1 — token doubling

For LiteLLM streaming agents, the raw `response_metadata.usage` arrives as an exact integer multiple (2×) of the agent-normalized `usage_metadata`:

```
usage_metadata:    input 263, output 2531, reasoning 18   ← correct
response_metadata: prompt 526, completion 5062, reasoning 36   ← doubled
```

`preserveLiteLLMUsage` promoted those doubled raw counts over the correct normalized ones (`shouldUseRawCount` fired because 263 ≠ 526). Input and output were counted twice; reasoning escaped only because it's read from the un-doubled `usage_metadata` path first.

**Fix:**
- Detect when raw usage is a clean integer multiple (≥2) of the normalized counts across all comparable positive fields, and divide it back down before merging.
- Add a **trust gate**: only adopt raw counts when they agree with the normalized totals, are a normalized duplicate, or are a *reasoning-inclusive repair* (raw completion includes reasoning that normalized output excludes). Otherwise keep the self-consistent `usage_metadata` and `logger.warn`, instead of blindly overwriting as the old code did.

This is strictly safer than the previous `shouldUseRawCount`: every point where behavior diverges from the old path, it favors the self-consistent value and surfaces anything unexpected via a warning.

## Bug 2 — internal margin leaked into the UI

Cost is computed as `tokens × base per-token rate` from LiteLLM `/model/info` (already un-margined). The breakdown *also* fetched LiteLLM's `cost_margin_config` (a 17% internal markup) and multiplied every cost by `1 + margin`, double-billing the user-facing number. The 17% is internal and shouldn't appear in the breakdown.

**Fix:** remove the margin multiplier, the `fetchCostMargin` client helper, and the `/api/forked/litellm/cost-margin` proxy route. No `-17%` correction needed — we simply stop applying a markup to an already-base cost.

## Tests

New/updated coverage for: duplicate normalization, the trust gate (including the ignored-inconsistent-raw + warn path), reasoning-inclusive repair, zero-placeholder restore, cache details, and base-rate cost splitting.

```
PASS  modelEndHandlerUsage.spec.js
PASS  syncResponseUsage.spec.js
PASS  syncResponseUsage.db.spec.js
PASS  ResponseCost.spec.ts
```
All changes confined to `forked-code` / `forked-code-custom`; lint clean.

## Post-deploy check

Eyeball one real reasoning message and confirm the breakdown matches LiteLLM's base cost, and that no `Ignored inconsistent raw stream usage` warnings appear on normal traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)